### PR TITLE
#70 - feat: frontend for chat summaries

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,0 @@
-MONGO_URI=mongodb+srv://samayafaheemanwar:adminuser@clustertest.vdp4k.mongodb.net/ClusterTest?retryWrites=true&w=majority
-PORT=5001
-JWT_SECRET=K23hBjjguyv88fy23Xbfur
-

--- a/frontend/src/api/get/getChatSummary.js
+++ b/frontend/src/api/get/getChatSummary.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const apiUrl = process.env.REACT_APP_BACKEND_API_URL;
+
+const getChatSummary = async (channel) => {
+    try {
+      const response = await axios.get(`${apiUrl}/api/summarization/${channel}`);
+      return response.data;
+    } catch (error) {
+      console.error(`Error fetching summary for channel "${channel}":`, error);
+      throw error;
+    }
+  };
+  
+  export { getChatSummary };

--- a/frontend/src/components/Chatbox.js
+++ b/frontend/src/components/Chatbox.js
@@ -4,6 +4,7 @@ import { getMessages } from "../api/get/getMessages";
 import { deleteMessage } from "../api/delete/deleteMessage";
 import { io } from "socket.io-client";
 import { sendMessage } from "../api/post/sendMessage";
+import { getChatSummary } from "../api/get/getChatSummary";
 
 const API_URL = process.env.REACT_APP_BACKEND_API_URL;
 
@@ -15,6 +16,8 @@ const Chatbox = ({ selectedChat }) => {
 
   const username = localStorage.getItem("username") || "Anonymous";
   const role = localStorage.getItem("role");
+
+  const [summary, setSummary] = useState("");
 
   // Load messages for the selected chat
   useEffect(() => {
@@ -95,6 +98,17 @@ const Chatbox = ({ selectedChat }) => {
       console.error("Error deleting message:", error);
     }
   };
+  const onSummarize = async () => {
+    if (!selectedChat) return;
+
+    try {
+      const data = await getChatSummary(selectedChat);
+      setSummary(data.summary || "No summary available.");
+    } catch (error) {
+      console.error("Error fetching summary:", error);
+      setSummary("Could not generate summary.");
+    }
+  };
 
   return (
     <Box
@@ -142,6 +156,38 @@ const Chatbox = ({ selectedChat }) => {
           </Box>
         ))}
       </Box>
+      
+      <Box sx={{ marginBottom: 2 }}>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={onSummarize}
+          sx={{ marginRight: 2 }}
+        >
+          Summarize
+        </Button>
+        {summary && (
+          <Box
+            sx={{
+              marginTop: 2,
+              backgroundColor: "#2f3136",
+              padding: 2,
+              borderRadius: 1,
+            }}
+          >
+            <Typography variant="body1">{summary}</Typography>
+            <Button
+              variant="outlined"
+              color="inherit"
+              onClick={() => setSummary("")}
+              sx={{ marginTop: 1 }}
+            >
+              Close
+            </Button>
+          </Box>
+        )}
+      </Box>
+      
       <Box sx={{ display: "flex", marginTop: 2 }}>
         <TextField
           variant="outlined"


### PR DESCRIPTION
### Summary
frontend for chat summaries

### Changes Made
added getChatSummary.js in /src/api/get/ to fetch summaries from the backend.
updated Chatbox.js to include a Summarize button that fetches and displays the chat summary.

### Screenshots (if applicable)
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/96cb893b-f5f7-45f4-9b73-579d3ce9bdc7" />
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/e7885177-1e1a-4763-855a-30de8b613b39" />


### Additional Notes
You will need to add the OpenAI API key into your env file.